### PR TITLE
Add prop extraBottomInset to fix the unwanted bottom inset

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Android Support is not perfect, here is the supported list:
 | `enableAutomaticScroll`     | Yes                 |
 | `extraHeight`               | Yes                 |
 | `extraScrollHeight`         | Yes                 |
+| `extraBottomInset`          | Yes                 |
 | `enableResetScrollToCoords` | Yes                 |
 | `keyboardOpeningTime`       | No                  |
 
@@ -144,6 +145,7 @@ All the `ScrollView`/`FlatList` props will be passed.
 | `enableAutomaticScroll`     | `boolean`                        | When focus in `TextInput` will scroll the position, default is enabled.                        |
 | `extraHeight`               | `number`                         | Adds an extra offset when focusing the `TextInput`s.                                           |
 | `extraScrollHeight`         | `number`                         | Adds an extra offset to the keyboard. Useful if you want to stick elements above the keyboard. |
+| `extraBottomInset`          | `number`                         | Adds an extra bottom inset to the scrollable content when keyboard is open.                    |
 | `enableResetScrollToCoords` | `boolean`                        | Lets the user enable or disable automatic resetScrollToCoords.                                 |
 | `keyboardOpeningTime`       | `number`                         | Sets the delay time before scrolling to new position, default is 250                           |
 | `enableOnAndroid`           | `boolean`                        | Enable Android Support                                                                         |

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -52,6 +52,7 @@ export type KeyboardAwareHOCProps = {
   enableAutomaticScroll?: boolean,
   extraHeight?: number,
   extraScrollHeight?: number,
+  extraBottomInset?: number,
   keyboardOpeningTime?: number,
   onScroll?: Function,
   update?: Function,
@@ -96,6 +97,7 @@ export type KeyboardAwareHOCOptions = ?{
   enableAutomaticScroll: boolean,
   extraHeight: number,
   extraScrollHeight: number,
+  extraBottomInset: number,
   enableResetScrollToCoords: boolean,
   keyboardOpeningTime: number,
   viewIsInsideTabBar: boolean,
@@ -113,6 +115,7 @@ const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
   enableAutomaticScroll: true,
   extraHeight: _KAM_EXTRA_HEIGHT,
   extraScrollHeight: 0,
+  extraBottomInset: 0,
   enableResetScrollToCoords: true,
   keyboardOpeningTime: _KAM_KEYBOARD_OPENING_TIME,
   viewIsInsideTabBar: false,
@@ -184,6 +187,7 @@ function KeyboardAwareHOC(
       enableAutomaticScroll: hocOptions.enableAutomaticScroll,
       extraHeight: hocOptions.extraHeight,
       extraScrollHeight: hocOptions.extraScrollHeight,
+      extraBottomInset: hocOptions.extraBottomInset,
       enableResetScrollToCoords: hocOptions.enableResetScrollToCoords,
       keyboardOpeningTime: hocOptions.keyboardOpeningTime,
       viewIsInsideTabBar: hocOptions.viewIsInsideTabBar,
@@ -359,7 +363,7 @@ function KeyboardAwareHOC(
       // Automatically scroll to focused TextInput
       if (this.props.enableAutomaticScroll) {
         let keyboardSpace: number =
-          frames.endCoordinates.height + this.props.extraScrollHeight
+          frames.endCoordinates.height + this.props.extraBottomInset
         if (this.props.viewIsInsideTabBar) {
           keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
         }


### PR DESCRIPTION
This is added because we shouldn't always use extraScrollHeight to calculate the bottom inset of the content when keyboard is open. Some unwanted bottom inset occurs if we do.

**To Test**

Follow the steps in the [gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/448).