### PR TITLE
Open a method to refresh the scroll due to caret

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -405,6 +405,13 @@ function KeyboardAwareHOC(
       }
     }
 
+    _scrollingDelayFor( fieldId: ?number ) {
+      if ( fieldId === undefined ) { //triggered by keyboard
+        return this.props.keyboardOpeningTime || 0
+      }
+      return 0; //triggered programmatically
+    } 
+
     _refreshScrollForField( fieldId: ?number ) {
       if ( !this.state ) {
         return;
@@ -415,6 +422,8 @@ function KeyboardAwareHOC(
       if (!currentlyFocusedField || !responder ) {
         return
       }
+      const scrollingDelay = this._scrollingDelayFor( fieldId );
+
       //it is ok to not have a fieldId but if we do then it should be same with currentlyFocusedField
       if ( !( fieldId && ( currentlyFocusedField == fieldId ) || !fieldId ) ) {
         return
@@ -442,10 +451,10 @@ function KeyboardAwareHOC(
                       if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
                       {
                         //Scroll till the bottom of component
-                        this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace);
+                        this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace, scrollingDelay);
                       } else {
                         //Scroll till the caret is visible
-                        this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEndCoordinatesScreenY);
+                        this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEndCoordinatesScreenY, scrollingDelay);
                       }
                     }
                   }
@@ -551,7 +560,7 @@ function KeyboardAwareHOC(
       return this.props.extraScrollHeight + this._totalVerticalDistanceToWindow();
     }
 
-    _doScrollToBottomOfComponent(currentlyFocusedField: number, y: number, height: number, keyboardEndCoordinatesScreenY: number, keyboardSpace: number) {
+    _doScrollToBottomOfComponent(currentlyFocusedField: number, y: number, height: number, keyboardEndCoordinatesScreenY: number, keyboardSpace: number, keyboardOpeningTime?: number) {
       // Check if the TextInput will be hidden by the keyboard
       const textInputBottomPosition = y + height
       const keyboardPosition = keyboardEndCoordinatesScreenY
@@ -563,7 +572,9 @@ function KeyboardAwareHOC(
           keyboardPosition - totalExtraHeight
         ) {
           this._scrollToFocusedInputWithNodeHandle(
-            currentlyFocusedField
+            currentlyFocusedField, 
+            null, 
+            keyboardOpeningTime
           )
         }
       } else {

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -65,7 +65,8 @@ export type KeyboardAwareHOCProps = {
   ...keyboardAwareHOCTypeEvents
 }
 export type KeyboardAwareHOCState = {
-  keyboardSpace: number
+  keyboardSpace: number, 
+  keyboardEndCoordinatesScreenY: number,
 }
 
 export type ElementLayout = {
@@ -163,6 +164,7 @@ function KeyboardAwareHOC(
     mountedComponent: boolean
     handleOnScroll: Function
     handleOnLayout: Function
+    refreshScrollForField: Function
     state: KeyboardAwareHOCState
     parentLayout: any
     bottomDistanceToWindow: number
@@ -219,6 +221,7 @@ function KeyboardAwareHOC(
         ? _KAM_DEFAULT_TAB_BAR_HEIGHT
         : 0
       this.state = { keyboardSpace }
+      this.refreshScrollForField = this._refreshScrollForField.bind( this );
     }
 
     async componentDidMount() {
@@ -392,47 +395,8 @@ function KeyboardAwareHOC(
         if (this.props.viewIsInsideTabBar) {
           keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
         }
-        this.setState({ keyboardSpace })
-        const currentlyFocusedField = TextInput.State.currentlyFocusedField()
-        const responder = this.getScrollResponder()
-        if (!currentlyFocusedField || !responder) {
-          return
-        }
-        UIManager.viewIsDescendantOf(
-          currentlyFocusedField,
-          responder.getInnerViewNode(),
-          (isAncestor: boolean) => {
-            if (isAncestor) {
-              if (Platform.OS === 'android') {
-                this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEvent, keyboardSpace);
-              } else {
-                UIManager.measureSelectionInWindow(
-                  currentlyFocusedField,
-                  (error: ?string, fieldX: number, fieldY: number, fieldWidth: number, fieldHeight: number, 
-                    caretX: number, caretY: number, caretRelativeX: number, caretRelativeY: number, 
-                    caretWidth: number, caretHeight: number, textInputBottomTextInset: number ) => {
-                    if ( error ) {
-                      //Try old way
-                      this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEvent, keyboardSpace);
-                    } else {
-                      // adjust scroll offset only if caret will remain out of viewable area
-                      if ( this._isCaretOutOfViewableArea(caretY, caretHeight, keyboardEvent) ) { 
-                        //Decide if we should scroll to the caret or to the bottom of the component
-                        if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEvent) )
-                        {
-                          //Scroll till the bottom of component
-                          this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEvent, keyboardSpace);
-                        } else {
-                          //Scroll till the caret is visible
-                          this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEvent);
-                        }
-                      }
-                    }
-                });
-              }
-            }
-          }
-        )
+        this.setState({ keyboardSpace, keyboardEndCoordinatesScreenY: keyboardEvent.endCoordinates.screenY})
+        this._refreshScrollForField()
       }
       if (!this.props.resetScrollToCoords) {
         if (!this.defaultResetScrollToCoords) {
@@ -441,6 +405,56 @@ function KeyboardAwareHOC(
       }
     }
 
+    _refreshScrollForField( fieldId: ?number ) {
+      if ( !this.state ) {
+        return;
+      }
+      const { keyboardSpace, keyboardEndCoordinatesScreenY } = this.state;
+      const currentlyFocusedField = TextInput.State.currentlyFocusedField()
+      const responder = this.getScrollResponder()
+      if (!currentlyFocusedField || !responder ) {
+        return
+      }
+      //it is ok to not have a fieldId but if we do then it should be same with currentlyFocusedField
+      if ( !( fieldId && ( currentlyFocusedField == fieldId ) || !fieldId ) ) {
+        return
+      }
+      UIManager.viewIsDescendantOf(
+        currentlyFocusedField,
+        responder.getInnerViewNode(),
+        (isAncestor: boolean) => {
+          if (isAncestor) {
+            if (Platform.OS === 'android') {
+              this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
+            } else {
+              UIManager.measureSelectionInWindow(
+                currentlyFocusedField,
+                (error: ?string, fieldX: number, fieldY: number, fieldWidth: number, fieldHeight: number, 
+                  caretX: number, caretY: number, caretRelativeX: number, caretRelativeY: number, 
+                  caretWidth: number, caretHeight: number, textInputBottomTextInset: number ) => {
+                  if ( error ) {
+                    //Try old way
+                    this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
+                  } else {
+                    // adjust scroll offset only if caret will remain out of viewable area
+                    if ( this._isCaretOutOfViewableArea(caretY, caretHeight, keyboardEndCoordinatesScreenY) ) { 
+                      //Decide if we should scroll to the caret or to the bottom of the component
+                      if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
+                      {
+                        //Scroll till the bottom of component
+                        this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace);
+                      } else {
+                        //Scroll till the caret is visible
+                        this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEndCoordinatesScreenY);
+                      }
+                    }
+                  }
+              });
+            }
+          }
+        }
+      )
+    }
     _totalVerticalDistanceToWindow() {
       return this.topDistanceToWindow + this.bottomDistanceToWindow + this.props.extraBottomInset;
     }
@@ -449,7 +463,7 @@ function KeyboardAwareHOC(
       currentlyFocusedField: number, 
       caretRelativeY: number, 
       caretHeight: number, 
-      keyboardEvent: Object, 
+      keyboardEndCoordinatesScreenY: number, 
       keyboardOpeningTime?: number) 
       {
       if ( keyboardOpeningTime === undefined ) {
@@ -462,7 +476,7 @@ function KeyboardAwareHOC(
         width: number,
         height: number) => {
 
-        let keyboardScreenY = keyboardEvent.endCoordinates.screenY;
+        let keyboardScreenY = keyboardEndCoordinatesScreenY;
         let extraScrollHeigth = caretHeight/2; //show half of the bottom line
         let scrollOffsetY = y - keyboardScreenY + caretHeight + extraScrollHeigth + caretRelativeY + this._totalVerticalDistanceToWindow();
         scrollOffsetY = Math.max(0, scrollOffsetY); //prevent negative scroll offset
@@ -494,17 +508,17 @@ function KeyboardAwareHOC(
       return ( caretY + 2*caretHeight + textInputBottomTextInset ) > ( fieldY + fieldHeight ) 
     }
 
-    _isFocusedAreaFitsInViewableArea(caretY: number, fieldY: number, fieldHeight: number, keyboardEvent: Object) {
+    _isFocusedAreaFitsInViewableArea(caretY: number, fieldY: number, fieldHeight: number, keyboardEndCoordinatesScreenY: number) {
       const distanceBetweenCaretAndBottomOfField =  fieldY + fieldHeight - caretY + this.props.extraScrollHeight;
       const viewableAreaStartY = this.topDistanceToWindow;
-      const viewableAreaEndY = keyboardEvent.endCoordinates.screenY - this.props.inputAccessoryViewHeight;
+      const viewableAreaEndY = keyboardEndCoordinatesScreenY - this.props.inputAccessoryViewHeight;
       const viewableAreaHeight = viewableAreaEndY - viewableAreaStartY;
       return viewableAreaHeight > distanceBetweenCaretAndBottomOfField;
     }
 
-    _isCaretUnderKeyboard(caretY: number, caretHeight: number, keyboardEvent: Object) {
+    _isCaretUnderKeyboard(caretY: number, caretHeight: number, keyboardEndCoordinatesScreenY) {
       const caretBottomPosition = caretY + caretHeight;
-      const keyboardPosition = keyboardEvent.endCoordinates.screenY
+      const keyboardPosition = keyboardEndCoordinatesScreenY
       return caretBottomPosition > (keyboardPosition - this.props.inputAccessoryViewHeight);
     }
 
@@ -512,23 +526,23 @@ function KeyboardAwareHOC(
       return this.topDistanceToWindow > caretY;
     }
 
-    _isCaretOutOfViewableArea(caretY: number, caretHeight: number, keyboardEvent: Object) {
-      return this._isCaretUnderKeyboard(caretY, caretHeight, keyboardEvent) || 
+    _isCaretOutOfViewableArea(caretY: number, caretHeight: number, keyboardEndCoordinatesScreenY: number) {
+      return this._isCaretUnderKeyboard(caretY, caretHeight, keyboardEndCoordinatesScreenY) || 
             this._isCaretAboveViewableArea(caretY);
     }
     
-    _shouldScrollToBottomOfComponent(fieldY: number, fieldHeight: number, caretY: number, caretHeight: number, textInputBottomTextInset: number, keyboardEvent: Object) 
+    _shouldScrollToBottomOfComponent(fieldY: number, fieldHeight: number, caretY: number, caretHeight: number, textInputBottomTextInset: number, keyboardEndCoordinatesScreenY: number) 
     { //is there enough place in the viewable area when keyboard is open?
-      return this._isFocusedAreaFitsInViewableArea( caretY, fieldY, fieldHeight, keyboardEvent) && 
+      return this._isFocusedAreaFitsInViewableArea( caretY, fieldY, fieldHeight, keyboardEndCoordinatesScreenY) && 
             //is the caret at the last line of the component?
             this._isCaretAtLastLine(caretY, caretHeight, fieldY, fieldHeight, textInputBottomTextInset); 
     }
 
-    _scrollToBottomOfComponent(currentlyFocusedField: number, keyboardEvent: Object, keyboardSpace: number) {
+    _scrollToBottomOfComponent(currentlyFocusedField: number, keyboardEndCoordinatesScreenY: number, keyboardSpace: number) {
       UIManager.measureInWindow(
         currentlyFocusedField,
         (x: number, y: number, width: number, height: number) => {
-          this._doScrollToBottomOfComponent(currentlyFocusedField, y, height, keyboardEvent, keyboardSpace);
+          this._doScrollToBottomOfComponent(currentlyFocusedField, y, height, keyboardEndCoordinatesScreenY, keyboardSpace);
         }
       );
     }
@@ -537,10 +551,10 @@ function KeyboardAwareHOC(
       return this.props.extraScrollHeight + this._totalVerticalDistanceToWindow();
     }
 
-    _doScrollToBottomOfComponent(currentlyFocusedField: number, y: number, height: number, keyboardEvent: Object, keyboardSpace: number) {
+    _doScrollToBottomOfComponent(currentlyFocusedField: number, y: number, height: number, keyboardEndCoordinatesScreenY: number, keyboardSpace: number) {
       // Check if the TextInput will be hidden by the keyboard
       const textInputBottomPosition = y + height
-      const keyboardPosition = keyboardEvent.endCoordinates.screenY
+      const keyboardPosition = keyboardEndCoordinatesScreenY
       const totalExtraHeight =
         this._extraScrollHeight() + this.props.extraHeight
       if (Platform.OS === 'ios') {
@@ -673,6 +687,7 @@ function KeyboardAwareHOC(
           keyboardSpace={this.state.keyboardSpace}
           getScrollResponder={this.getScrollResponder}
           scrollToPosition={this.scrollToPosition}
+          refreshScrollForField={this.refreshScrollForField}
           scrollToEnd={this.scrollToEnd}
           scrollForExtraHeightOnAndroid={this.scrollForExtraHeightOnAndroid}
           scrollToFocusedInput={this.scrollToFocusedInput}

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -395,7 +395,7 @@ function KeyboardAwareHOC(
           keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
         }
         this.setState({ keyboardSpace, keyboardEndCoordinatesScreenY: keyboardEvent.endCoordinates.screenY})
-        this._refreshScrollForField(null, true)
+        this._refreshScrollForField(null)
       }
       if (!this.props.resetScrollToCoords) {
         if (!this.defaultResetScrollToCoords) {
@@ -411,7 +411,7 @@ function KeyboardAwareHOC(
       return 0; //triggered programmatically
     } 
 
-    async _refreshScrollForField( fieldId: ?number, triggeredByKeyboard: boolean) {
+    async _refreshScrollForField( fieldId: ?number ) {
       await this._calculateTopBottomDistanceIfNeeded();
 
       if ( !this.state ) {
@@ -449,7 +449,7 @@ function KeyboardAwareHOC(
                     // adjust scroll offset only if caret will remain out of viewable area
                     if ( this._isCaretOutOfViewableArea(caretY, caretHeight, keyboardEndCoordinatesScreenY) ) { 
                       //Decide if we should scroll to the caret or to the bottom of the component
-                      if( this._shouldScrollToBottomOfComponent(triggeredByKeyboard, fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
+                      if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
                       {
                         //Scroll till the bottom of component
                         this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace, scrollingDelay);
@@ -541,12 +541,9 @@ function KeyboardAwareHOC(
             this._isCaretAboveViewableArea(caretY);
     }
     
-    _shouldScrollToBottomOfComponent(triggeredByKeyboard: boolean, fieldY: number, fieldHeight: number, caretY: number, caretHeight: number, textInputBottomTextInset: number, keyboardEndCoordinatesScreenY: number) 
+    _shouldScrollToBottomOfComponent(fieldY: number, fieldHeight: number, caretY: number, caretHeight: number, textInputBottomTextInset: number, keyboardEndCoordinatesScreenY: number) 
     {
-      if ( !triggeredByKeyboard ) { 
-        return false;
-      }
-       //is there enough place in the viewable area when keyboard is open?
+      //is there enough place in the viewable area when keyboard is open?
       return this._isFocusedAreaFitsInViewableArea( caretY, fieldY, fieldHeight, keyboardEndCoordinatesScreenY) && 
             //is the caret at the last line of the component?
             this._isCaretAtLastLine(caretY, caretHeight, fieldY, fieldHeight, textInputBottomTextInset); 

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -449,7 +449,7 @@ function KeyboardAwareHOC(
                     // adjust scroll offset only if caret will remain out of viewable area
                     if ( this._isCaretOutOfViewableArea(caretY, caretHeight, keyboardEndCoordinatesScreenY) ) { 
                       //Decide if we should scroll to the caret or to the bottom of the component
-                      if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
+                      if( this._shouldScrollToBottomOfComponent(triggeredByKeyboard, fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
                       {
                         //Scroll till the bottom of component
                         this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace, scrollingDelay);
@@ -541,8 +541,12 @@ function KeyboardAwareHOC(
             this._isCaretAboveViewableArea(caretY);
     }
     
-    _shouldScrollToBottomOfComponent(fieldY: number, fieldHeight: number, caretY: number, caretHeight: number, textInputBottomTextInset: number, keyboardEndCoordinatesScreenY: number) 
-    { //is there enough place in the viewable area when keyboard is open?
+    _shouldScrollToBottomOfComponent(triggeredByKeyboard: boolean, fieldY: number, fieldHeight: number, caretY: number, caretHeight: number, textInputBottomTextInset: number, keyboardEndCoordinatesScreenY: number) 
+    {
+      if ( !triggeredByKeyboard ) { 
+        return false;
+      }
+       //is there enough place in the viewable area when keyboard is open?
       return this._isFocusedAreaFitsInViewableArea( caretY, fieldY, fieldHeight, keyboardEndCoordinatesScreenY) && 
             //is the caret at the last line of the component?
             this._isCaretAtLastLine(caretY, caretHeight, fieldY, fieldHeight, textInputBottomTextInset); 

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -386,7 +386,6 @@ function KeyboardAwareHOC(
 
     // Keyboard actions
    _updateKeyboardSpace = async (keyboardEvent: Object) => {
-      await this._calculateTopBottomDistanceIfNeeded();
 
       // Automatically scroll to focused TextInput
       if (this.props.enableAutomaticScroll) {
@@ -396,7 +395,7 @@ function KeyboardAwareHOC(
           keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
         }
         this.setState({ keyboardSpace, keyboardEndCoordinatesScreenY: keyboardEvent.endCoordinates.screenY})
-        this._refreshScrollForField()
+        this._refreshScrollForField(null, true)
       }
       if (!this.props.resetScrollToCoords) {
         if (!this.defaultResetScrollToCoords) {
@@ -412,7 +411,9 @@ function KeyboardAwareHOC(
       return 0; //triggered programmatically
     } 
 
-    _refreshScrollForField( fieldId: ?number ) {
+    async _refreshScrollForField( fieldId: ?number, triggeredByKeyboard: boolean) {
+      await this._calculateTopBottomDistanceIfNeeded();
+
       if ( !this.state ) {
         return;
       }


### PR DESCRIPTION
This PR extracts a new method to refresh the scroll position for a specific component due to the caret position. This is to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/464

**To Test**
Follow the steps on [gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/474)