### PR TITLE
Fix textinput caret position, y position and height calculating wrongly

### DIFF
--- a/ios/RNKeyboardAwareScrollView/RCTUIManager+Additions.m
+++ b/ios/RNKeyboardAwareScrollView/RCTUIManager+Additions.m
@@ -1,6 +1,8 @@
 #import "RCTUIManager+Additions.h"
 #import <UIKit/UIKit.h>
 
+const CGFloat RNTDetectCaretPositionTrialCount = 20;
+
 @implementation RCTUIManager (Additions)
 
 RCT_EXPORT_METHOD(measureSelectionInWindow:(nonnull NSNumber *)reactTag callback:(RCTResponseSenderBlock)callback)
@@ -12,34 +14,75 @@ RCT_EXPORT_METHOD(measureSelectionInWindow:(nonnull NSNumber *)reactTag callback
             callback(@[@"View doesn't exist"]);
             return;
         }
-        CGRect windowFrame = [newResponder.window convertRect:newResponder.frame fromView:newResponder.superview];
         if ( [newResponder conformsToProtocol:@protocol(UITextInput)] ) {
             id<UITextInput> textInput = (id<UITextInput>)newResponder;
             UITextPosition *endPosition = textInput.selectedTextRange.end;
             if ( endPosition ) {
-                CGRect selectionEndRect = [textInput caretRectForPosition:endPosition];
-                CGFloat textInputBottomTextInset = 0;
-                if ( [textInput isKindOfClass:[UITextView class]] ) {
-                    textInputBottomTextInset = ((UITextView *)textInput).textContainerInset.bottom;
-                }
-                callback(@[[NSNull null],
-                           @(windowFrame.origin.x),  //text input x
-                           @(windowFrame.origin.y),  //text input y
-                           @(windowFrame.size.width),  //text input width
-                           @(windowFrame.size.height),  //text input height
-                           @(windowFrame.origin.x + selectionEndRect.origin.x),  //caret x
-                           @(windowFrame.origin.y + selectionEndRect.origin.y),  //caret y
-                           @(selectionEndRect.origin.x),  //caret relative x
-                           @(selectionEndRect.origin.y),  //caret relative y
-                           @(selectionEndRect.size.width),  //caret width
-                           @(selectionEndRect.size.height),  //caret height
-                           @(textInputBottomTextInset)  // text input bottom text inset
-                           ]);
+                [self rnt_caretRectIn:textInput trialCount:RNTDetectCaretPositionTrialCount completion:^(NSError *error, CGRect selectionEndRect) {
+                    if (error) {
+                        RCTLogWarn(@"measureSelectionInWindow cannot find the caret position in view with tag #%@", reactTag);
+                        callback(@[@"Caret position could not be determined"]);
+                        return;
+                    }
+                    CGRect windowFrame = [newResponder.window convertRect:newResponder.frame fromView:newResponder.superview];
+                    CGFloat textViewHeight = [self rnt_contentHeightIn:textInput defaultHeight:windowFrame.size.height];
+                    CGFloat textInputBottomTextInset = 0;
+                    if ( [textInput isKindOfClass:[UITextView class]] ) {
+                        textInputBottomTextInset = ((UITextView *)textInput).textContainerInset.bottom;
+                    }
+                    callback(@[[NSNull null],
+                               @(windowFrame.origin.x),  //text input x
+                               @(windowFrame.origin.y),  //text input y
+                               @(windowFrame.size.width),  //text input width
+                               @(textViewHeight),  //text input height
+                               @(windowFrame.origin.x + selectionEndRect.origin.x),  //caret x
+                               @(windowFrame.origin.y + selectionEndRect.origin.y),  //caret y
+                               @(selectionEndRect.origin.x),  //caret relative x
+                               @(selectionEndRect.origin.y),  //caret relative y
+                               @(selectionEndRect.size.width),  //caret width
+                               @(selectionEndRect.size.height),  //caret height
+                               @(textInputBottomTextInset)  // text input bottom text inset
+                               ]);
+                    return;
+                    
+                }];
                 return;
             }
         }
         callback(@[@"Text selection not available"]);
     }];
+}
+
+- (CGFloat)rnt_contentHeightIn:(id<UITextInput>)textInput defaultHeight:(CGFloat)defaultHeight {
+    if ([textInput isKindOfClass:[UITextView class]]) {
+        UITextView *textView = (UITextView *)textInput;
+        // This is a workaround to get the result height of the textview after its content is changed
+        // sometimes at this point the height of the textview is calculated wrongly and
+        // calling layoutIfNeeded doesn't help with that so we call sizeThatFits
+        return [textView sizeThatFits:textView.frame.size].height;
+    }
+    return defaultHeight;
+}
+
+- (void)rnt_caretRectIn:(id<UITextInput>)textInput trialCount:(NSInteger)trialCount completion:(void (^)(NSError *error, CGRect rect))completion {
+    if ( trialCount == 0 ) {
+        //We tried but couldn't find, return an error
+        completion([NSError new], CGRectZero);
+        return;
+    }
+    UITextPosition *endPosition = textInput.selectedTextRange.end;
+    CGRect selectionEndRect = [textInput caretRectForPosition:endPosition];
+    if ((CGRectGetMinY(selectionEndRect) < 0) ||
+        (INFINITY == CGRectGetMinY(selectionEndRect))) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(),
+                       ^{
+                           // Recall
+                           [self rnt_caretRectIn:textInput trialCount:trialCount - 1 completion: completion];
+                       });
+        return;
+    }
+    completion(nil, selectionEndRect);
 }
 
 @end

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -16,6 +16,8 @@ import type { KeyboardAwareInterface } from './KeyboardAwareInterface'
 
 const _KAM_DEFAULT_TAB_BAR_HEIGHT: number = isIphoneX() ? 83 : 49
 const _KAM_KEYBOARD_OPENING_TIME: number = 250
+const _KAM_EXTRA_LAYOUT_DELAY: number = 200
+const _KEYBOARD_OPEN_CLOSE_USER_NOTICE_THRESHOLD = 300;
 const _KAM_EXTRA_HEIGHT: number = 75
 
 const supportedKeyboardEvents = [
@@ -169,6 +171,8 @@ function KeyboardAwareHOC(
     parentLayout: any
     bottomDistanceToWindow: number
     topDistanceToWindow: number
+    keyboardWillHideTime: number
+
     static displayName = `KeyboardAware${getDisplayName(ScrollableComponent)}`
 
     static propTypes = {
@@ -256,7 +260,7 @@ function KeyboardAwareHOC(
         }
       })
     }
-
+  
     componentWillReceiveProps(nextProps: KeyboardAwareHOCProps) {
       if (nextProps.viewIsInsideTabBar !== this.props.viewIsInsideTabBar) {
         const keyboardSpace: number = nextProps.viewIsInsideTabBar
@@ -384,9 +388,23 @@ function KeyboardAwareHOC(
       }
     }
 
+    _wasKeyboardAlreadyOpen(keyboardWillOpenTime: number) {
+      //happens when keyboard opens/closes very fast that user won't even notice
+      return  ( keyboardWillOpenTime - this.keyboardWillHideTime ) < _KEYBOARD_OPEN_CLOSE_USER_NOTICE_THRESHOLD;
+    }
+
+    _calculateLayoutDelayOnKeyboardWillOpen(keyboardWillOpenTime: number) {
+      var layoutDelay = 0;
+      if ( this._wasKeyboardAlreadyOpen( keyboardWillOpenTime ) ) {
+        layoutDelay = _KAM_EXTRA_LAYOUT_DELAY;
+        this.keyboardWillHideTime = 0; //Reset until next keyboard hide
+      }
+      return layoutDelay;
+    }
+
     // Keyboard actions
    _updateKeyboardSpace = async (keyboardEvent: Object) => {
-
+      const layoutDelay = this._calculateLayoutDelayOnKeyboardWillOpen( Date.now() );
       // Automatically scroll to focused TextInput
       if (this.props.enableAutomaticScroll) {
         let keyboardSpace: number =
@@ -395,7 +413,9 @@ function KeyboardAwareHOC(
           keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
         }
         this.setState({ keyboardSpace, keyboardEndCoordinatesScreenY: keyboardEvent.endCoordinates.screenY})
-        this._refreshScrollForField(null)
+        setTimeout(() => {
+          this._refreshScrollForField(null);
+        }, layoutDelay); //give some time to layout
       }
       if (!this.props.resetScrollToCoords) {
         if (!this.defaultResetScrollToCoords) {
@@ -604,6 +624,7 @@ function KeyboardAwareHOC(
     }
 
     _resetKeyboardSpace = () => {
+      this.keyboardWillHideTime = Date.now();
       const keyboardSpace: number = this.props.viewIsInsideTabBar
         ? _KAM_DEFAULT_TAB_BAR_HEIGHT
         : 0

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -17,7 +17,7 @@ import type { KeyboardAwareInterface } from './KeyboardAwareInterface'
 const _KAM_DEFAULT_TAB_BAR_HEIGHT: number = isIphoneX() ? 83 : 49
 const _KAM_KEYBOARD_OPENING_TIME: number = 250
 const _KAM_EXTRA_LAYOUT_DELAY: number = 200
-const _KEYBOARD_OPEN_CLOSE_USER_NOTICE_THRESHOLD = 300;
+const _KEYBOARD_OPEN_CLOSE_USER_NOTICE_THRESHOLD = 500;
 const _KAM_EXTRA_HEIGHT: number = 75
 
 const supportedKeyboardEvents = [


### PR DESCRIPTION
Swift side:
Caret position is not immediately available when the typing goes into a new line so we are trying to detect it by checking again and again for maximum of 1 seconds.

JS side:

Also we are giving an extra delay for the case where keyboard was closed and opened very closely (like in case of a block split), in that case a bit of delay helps us calculate dimensions more correctly. Not the most elegant solution but 🤷‍♀️ 
 
**TO TEST**
Refer to [gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/554)