### PR TITLE
Replace isDescendant check with a more decent one

### DIFF
--- a/ios/RNTKeyboardAwareScrollView/RNTKeyboardAwareScrollView.m
+++ b/ios/RNTKeyboardAwareScrollView/RNTKeyboardAwareScrollView.m
@@ -17,6 +17,26 @@ RCT_EXPORT_MODULE()
     return YES;
 }
 
+RCT_EXPORT_METHOD(viewInSameViewController:(nonnull NSNumber *)reactTag
+                  ancestor:(nonnull NSNumber *)ancestorReactTag
+                  callback:(RCTResponseSenderBlock)callback) {
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        UIView *inputView = [uiManager viewForReactTag:reactTag];
+        UIView *ancestorView = [uiManager viewForReactTag:ancestorReactTag];
+        if ( !inputView || !ancestorView) {
+            callback(@[@"Couldn't find views"]);
+            return;
+        }
+        UIViewController *viewControllerInputView = inputView.reactViewController;
+        UIViewController *viewControllerAncestorView = ancestorView.reactViewController;
+        if ( viewControllerInputView != viewControllerAncestorView ){
+            callback(@[[NSNull null], @(NO)]);
+            return;
+        }
+        callback(@[[NSNull null], @(YES)]);
+    }];
+}
+
 RCT_EXPORT_METHOD(measureSelectionInWindow:(nonnull NSNumber *)reactTag callback:(RCTResponseSenderBlock)callback)
 {
     __weak typeof(self) weakSelf = self;

--- a/ios/RNTKeyboardAwareScrollView/RNTKeyboardAwareScrollView.m
+++ b/ios/RNTKeyboardAwareScrollView/RNTKeyboardAwareScrollView.m
@@ -23,7 +23,7 @@ RCT_EXPORT_METHOD(viewIsDescendantOf:(nonnull NSNumber *)reactTag
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
         UIView *inputView = [uiManager viewForReactTag:reactTag];
         UIView *ancestorView = [uiManager viewForReactTag:ancestorReactTag];
-        if ( !inputView || !ancestorView) {
+        if (!inputView || !ancestorView) {
             callback(@[@"Couldn't find views"]);
             return;
         }

--- a/ios/RNTKeyboardAwareScrollView/RNTKeyboardAwareScrollView.m
+++ b/ios/RNTKeyboardAwareScrollView/RNTKeyboardAwareScrollView.m
@@ -17,7 +17,7 @@ RCT_EXPORT_MODULE()
     return YES;
 }
 
-RCT_EXPORT_METHOD(viewInSameViewController:(nonnull NSNumber *)reactTag
+RCT_EXPORT_METHOD(viewIsDescendantOf:(nonnull NSNumber *)reactTag
                   ancestor:(nonnull NSNumber *)ancestorReactTag
                   callback:(RCTResponseSenderBlock)callback) {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
@@ -27,13 +27,8 @@ RCT_EXPORT_METHOD(viewInSameViewController:(nonnull NSNumber *)reactTag
             callback(@[@"Couldn't find views"]);
             return;
         }
-        UIViewController *viewControllerInputView = inputView.reactViewController;
-        UIViewController *viewControllerAncestorView = ancestorView.reactViewController;
-        if ( viewControllerInputView != viewControllerAncestorView ){
-            callback(@[[NSNull null], @(NO)]);
-            return;
-        }
-        callback(@[[NSNull null], @(YES)]);
+        BOOL result = [inputView isDescendantOfView:ancestorView];
+        callback(@[[NSNull null], @(result)]);
     }];
 }
 

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -452,42 +452,51 @@ function KeyboardAwareHOC(
       if ( !( fieldId && ( currentlyFocusedField == fieldId ) || !fieldId ) ) {
         return
       }
-      UIManager.viewIsDescendantOf(
-        currentlyFocusedField,
+      RNTKeyboardAwareScrollView.viewInSameViewController(
+        currentlyFocusedField, 
         responder.getInnerViewNode(),
-        (isAncestor: boolean) => {
-          if (isAncestor) {
-            if (Platform.OS === 'android') {
-              this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
-            } else {
-              RNTKeyboardAwareScrollView.measureSelectionInWindow(
-                currentlyFocusedField,
-                (error: ?string, fieldX: number, fieldY: number, fieldWidth: number, fieldHeight: number, 
-                  caretX: number, caretY: number, caretRelativeX: number, caretRelativeY: number, 
-                  caretWidth: number, caretHeight: number, textInputBottomTextInset: number ) => {
-                  if ( error ) {
-                    //Try old way
-                    this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
-                  } else {
-                    // adjust scroll offset only if caret will remain out of viewable area
-                    if ( this._isCaretOutOfViewableArea(caretY, caretHeight, keyboardEndCoordinatesScreenY) ) { 
-                      //Decide if we should scroll to the caret or to the bottom of the component
-                      if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
-                      {
-                        //Scroll till the bottom of component
-                        this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace, scrollingDelay);
-                      } else {
-                        //Scroll till the caret is visible
-                        this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEndCoordinatesScreenY, scrollingDelay);
+        ( error: ?string, inSameViewController: boolean ) => {
+        if ( !error && !inSameViewController ) {
+          return;
+        }
+        UIManager.viewIsDescendantOf(
+          currentlyFocusedField,
+          responder.getInnerViewNode(),
+          (isAncestor: boolean) => {
+            if (isAncestor) {
+              if (Platform.OS === 'android') {
+                this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
+              } else {
+                RNTKeyboardAwareScrollView.measureSelectionInWindow(
+                  currentlyFocusedField,
+                  (error: ?string, fieldX: number, fieldY: number, fieldWidth: number, fieldHeight: number, 
+                    caretX: number, caretY: number, caretRelativeX: number, caretRelativeY: number, 
+                    caretWidth: number, caretHeight: number, textInputBottomTextInset: number ) => {
+                    if ( error ) {
+                      //Try old way
+                      this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
+                    } else {
+                      // adjust scroll offset only if caret will remain out of viewable area
+                      if ( this._isCaretOutOfViewableArea(caretY, caretHeight, keyboardEndCoordinatesScreenY) ) { 
+                        //Decide if we should scroll to the caret or to the bottom of the component
+                        if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
+                        {
+                          //Scroll till the bottom of component
+                          this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace, scrollingDelay);
+                        } else {
+                          //Scroll till the caret is visible
+                          this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEndCoordinatesScreenY, scrollingDelay);
+                        }
                       }
                     }
-                  }
-              });
+                });
+              }
             }
           }
-        }
-      )
+        )
+      });
     }
+
     _totalVerticalDistanceToWindow() {
       return this.topDistanceToWindow + this.bottomDistanceToWindow + this.props.extraBottomInset;
     }

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -434,6 +434,32 @@ function KeyboardAwareHOC(
       return 0; //triggered programmatically
     } 
 
+    _viewIsDescendantOf(
+      currentlyFocusedField: number,
+      ancestorViewId: number,
+      callback: (isAncestor: boolean) => void
+      ) {
+      if ( Platform.OS === 'ios' ) {
+        RNTKeyboardAwareScrollView.viewIsDescendantOf(
+          currentlyFocusedField,
+          ancestorViewId,        
+          ( error: ?string, isAncestor: boolean ) => {
+            if ( error ) {
+              console.warn(`RNTKeyboardAwareScrollView.viewIsDescendantOf call returned error: ${ error }`);
+              return;
+            }
+            callback(isAncestor);
+          }
+        );
+      } else {
+        UIManager.viewIsDescendantOf(
+          currentlyFocusedField,
+          ancestorViewId,
+          callback
+        )
+      }
+    }
+
     async _refreshScrollForField( fieldId: ?number ) {
       await this._calculateTopBottomDistanceIfNeeded();
 
@@ -452,49 +478,41 @@ function KeyboardAwareHOC(
       if ( !( fieldId && ( currentlyFocusedField == fieldId ) || !fieldId ) ) {
         return
       }
-      RNTKeyboardAwareScrollView.viewInSameViewController(
-        currentlyFocusedField, 
+      this._viewIsDescendantOf(
+        currentlyFocusedField,
         responder.getInnerViewNode(),
-        ( error: ?string, inSameViewController: boolean ) => {
-        if ( !error && !inSameViewController ) {
-          return;
-        }
-        UIManager.viewIsDescendantOf(
-          currentlyFocusedField,
-          responder.getInnerViewNode(),
-          (isAncestor: boolean) => {
-            if (isAncestor) {
-              if (Platform.OS === 'android') {
-                this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
-              } else {
-                RNTKeyboardAwareScrollView.measureSelectionInWindow(
-                  currentlyFocusedField,
-                  (error: ?string, fieldX: number, fieldY: number, fieldWidth: number, fieldHeight: number, 
-                    caretX: number, caretY: number, caretRelativeX: number, caretRelativeY: number, 
-                    caretWidth: number, caretHeight: number, textInputBottomTextInset: number ) => {
-                    if ( error ) {
-                      //Try old way
-                      this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
-                    } else {
-                      // adjust scroll offset only if caret will remain out of viewable area
-                      if ( this._isCaretOutOfViewableArea(caretY, caretHeight, keyboardEndCoordinatesScreenY) ) { 
-                        //Decide if we should scroll to the caret or to the bottom of the component
-                        if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
-                        {
-                          //Scroll till the bottom of component
-                          this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace, scrollingDelay);
-                        } else {
-                          //Scroll till the caret is visible
-                          this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEndCoordinatesScreenY, scrollingDelay);
-                        }
+        (isAncestor: boolean) => {
+          if (isAncestor) {
+            if (Platform.OS === 'android') {
+              this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
+            } else {
+              RNTKeyboardAwareScrollView.measureSelectionInWindow(
+                currentlyFocusedField,
+                (error: ?string, fieldX: number, fieldY: number, fieldWidth: number, fieldHeight: number, 
+                  caretX: number, caretY: number, caretRelativeX: number, caretRelativeY: number, 
+                  caretWidth: number, caretHeight: number, textInputBottomTextInset: number ) => {
+                  if ( error ) {
+                    //Try old way
+                    this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
+                  } else {
+                    // adjust scroll offset only if caret will remain out of viewable area
+                    if ( this._isCaretOutOfViewableArea(caretY, caretHeight, keyboardEndCoordinatesScreenY) ) { 
+                      //Decide if we should scroll to the caret or to the bottom of the component
+                      if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
+                      {
+                        //Scroll till the bottom of component
+                        this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace, scrollingDelay);
+                      } else {
+                        //Scroll till the caret is visible
+                        this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEndCoordinatesScreenY, scrollingDelay);
                       }
                     }
-                });
-              }
+                  }
+              });
             }
           }
-        )
-      });
+        }
+      )
     }
 
     _totalVerticalDistanceToWindow() {


### PR DESCRIPTION
To fix: https://github.com/wordpress-mobile/gutenberg-mobile/issues/717

Autoscroll should only occur if the focused textInput is a subview of the scroll view. React native's UIManager.viewIsDescendantOf makes the check using shadows views and it generates true even if our TextInput is inside a new modal UIViewController, we don't want that. We just want a simple subview check like this: https://developer.apple.com/documentation/uikit/uiview/1622521-isdescendant

So we are replacing that check to avoid unwanted autoscrolls triggered from views that doesn't belong to our scrollview.

Test with:
gutenberg-mobile PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/767
WPiOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/11298