### PR TITLE
Fix compatibility with RN 0.60.0

### DIFF
--- a/react-native-keyboard-aware-scroll-view.podspec
+++ b/react-native-keyboard-aware-scroll-view.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files    = "ios/RNTKeyboardAwareScrollView/*.{h,m}"
   s.preserve_paths  = "**/*.js"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
This makes a change to be compatible with RN 0.60.0:

- Depend only on `React-Core` instead of all of React.