### PR TITLE
Fix caret scroll calculation

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -537,7 +537,7 @@ function KeyboardAwareHOC(
         height: number) => {
 
         let keyboardScreenY = keyboardEndCoordinatesScreenY;
-        let extraScrollHeigth = caretHeight/2; //show half of the bottom line
+        let extraScrollHeigth = caretHeight*2; //show extra space below the caret
         let scrollOffsetY = y - keyboardScreenY + caretHeight + extraScrollHeigth + caretRelativeY + this._totalVerticalDistanceToWindow();
         scrollOffsetY = Math.max(0, scrollOffsetY); //prevent negative scroll offset
         const responder = this.getScrollResponder();
@@ -587,7 +587,7 @@ function KeyboardAwareHOC(
     }
 
     _isCaretOutOfViewableArea(caretY: number, caretHeight: number, keyboardEndCoordinatesScreenY: number) {
-      return this._isCaretUnderKeyboard(caretY, caretHeight, keyboardEndCoordinatesScreenY) || 
+      return this._isCaretUnderKeyboard(caretY, caretHeight, keyboardEndCoordinatesScreenY - this.props.extraScrollHeight ) || 
             this._isCaretAboveViewableArea(caretY);
     }
     
@@ -609,7 +609,7 @@ function KeyboardAwareHOC(
     }
 
     _extraScrollHeight() {
-      return this.props.extraScrollHeight + this._totalVerticalDistanceToWindow();
+      return this.props.extraScrollHeight + this.topDistanceToWindow;
     }
 
     _doScrollToBottomOfComponent(currentlyFocusedField: number, y: number, height: number, keyboardEndCoordinatesScreenY: number, keyboardSpace: number, keyboardOpeningTime?: number) {
@@ -688,6 +688,7 @@ function KeyboardAwareHOC(
         extraHeight = this.props.extraHeight
       }
       const reactNode = ReactNative.findNodeHandle(nodeID)
+      console.log("extraHeight + _extraScrollHeight()", extraHeight, this._extraScrollHeight());
       this.scrollToFocusedInput(
         reactNode,
         extraHeight + this._extraScrollHeight(),

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -491,21 +491,30 @@ function KeyboardAwareHOC(
                 (error: ?string, fieldX: number, fieldY: number, fieldWidth: number, fieldHeight: number, 
                   caretX: number, caretY: number, caretRelativeX: number, caretRelativeY: number, 
                   caretWidth: number, caretHeight: number, textInputBottomTextInset: number ) => {
+                    console.log("---> got measurement");
+                    const { height: windowHeight } = Dimensions.get( 'window' );
+                    const viewableBottomCoordinateY = keyboardEndCoordinatesScreenY ? keyboardEndCoordinatesScreenY : windowHeight - this.props.extraScrollHeight;
                   if ( error ) {
                     //Try old way
-                    this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
+                    console.log("Error?", error);
+                    this._scrollToBottomOfComponent(currentlyFocusedField, viewableBottomCoordinateY, keyboardSpace);
                   } else {
                     // adjust scroll offset only if caret will remain out of viewable area
-                    if ( this._isCaretOutOfViewableArea(caretY, caretHeight, keyboardEndCoordinatesScreenY) ) { 
+                    if ( this._isCaretOutOfViewableArea(caretY, caretHeight, viewableBottomCoordinateY) ) { 
+                      console.log("+++Caret is out of viewable area!!! PLEASE SCROLL");
                       //Decide if we should scroll to the caret or to the bottom of the component
-                      if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
+                      if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, viewableBottomCoordinateY) )
                       {
+                        console.log("---> SCROLL to bottom");
                         //Scroll till the bottom of component
-                        this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace, scrollingDelay);
+                        this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, viewableBottomCoordinateY, keyboardSpace, scrollingDelay);
                       } else {
+                        console.log("SCROLL to caret");
                         //Scroll till the caret is visible
-                        this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEndCoordinatesScreenY, scrollingDelay);
+                        this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, viewableBottomCoordinateY, scrollingDelay);
                       }
+                    } else {
+                      console.log("==== Caret is NOT!!! outside.");
                     }
                   }
               });
@@ -609,7 +618,8 @@ function KeyboardAwareHOC(
     }
 
     _extraScrollHeight() {
-      return this.props.extraScrollHeight + this.topDistanceToWindow;
+      const verticalDistanceToWindow = (this.state.keyboardEndCoordinatesScreenY !== undefined) ? this.topDistanceToWindow : this._totalVerticalDistanceToWindow();
+      return this.props.extraScrollHeight + verticalDistanceToWindow;
     }
 
     _doScrollToBottomOfComponent(currentlyFocusedField: number, y: number, height: number, keyboardEndCoordinatesScreenY: number, keyboardSpace: number, keyboardOpeningTime?: number) {
@@ -658,7 +668,7 @@ function KeyboardAwareHOC(
       const keyboardSpace: number = this.props.viewIsInsideTabBar
         ? _KAM_DEFAULT_TAB_BAR_HEIGHT
         : 0
-      this.setState({ keyboardSpace })
+      this.setState({ keyboardSpace, keyboardEndCoordinatesScreenY: undefined })
       // Reset scroll position after keyboard dismissal
       if (this.props.enableResetScrollToCoords === false) {
         this.defaultResetScrollToCoords = null

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -491,30 +491,23 @@ function KeyboardAwareHOC(
                 (error: ?string, fieldX: number, fieldY: number, fieldWidth: number, fieldHeight: number, 
                   caretX: number, caretY: number, caretRelativeX: number, caretRelativeY: number, 
                   caretWidth: number, caretHeight: number, textInputBottomTextInset: number ) => {
-                    console.log("---> got measurement");
                     const { height: windowHeight } = Dimensions.get( 'window' );
                     const viewableBottomCoordinateY = keyboardEndCoordinatesScreenY ? keyboardEndCoordinatesScreenY : windowHeight - this.props.extraScrollHeight;
                   if ( error ) {
                     //Try old way
-                    console.log("Error?", error);
                     this._scrollToBottomOfComponent(currentlyFocusedField, viewableBottomCoordinateY, keyboardSpace);
                   } else {
                     // adjust scroll offset only if caret will remain out of viewable area
                     if ( this._isCaretOutOfViewableArea(caretY, caretHeight, viewableBottomCoordinateY) ) { 
-                      console.log("+++Caret is out of viewable area!!! PLEASE SCROLL");
                       //Decide if we should scroll to the caret or to the bottom of the component
                       if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, viewableBottomCoordinateY) )
                       {
-                        console.log("---> SCROLL to bottom");
                         //Scroll till the bottom of component
                         this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, viewableBottomCoordinateY, keyboardSpace, scrollingDelay);
                       } else {
-                        console.log("SCROLL to caret");
                         //Scroll till the caret is visible
                         this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, viewableBottomCoordinateY, scrollingDelay);
                       }
-                    } else {
-                      console.log("==== Caret is NOT!!! outside.");
                     }
                   }
               });

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -688,7 +688,6 @@ function KeyboardAwareHOC(
         extraHeight = this.props.extraHeight
       }
       const reactNode = ReactNative.findNodeHandle(nodeID)
-      console.log("extraHeight + _extraScrollHeight()", extraHeight, this._extraScrollHeight());
       this.scrollToFocusedInput(
         reactNode,
         extraHeight + this._extraScrollHeight(),

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -491,8 +491,7 @@ function KeyboardAwareHOC(
                 (error: ?string, fieldX: number, fieldY: number, fieldWidth: number, fieldHeight: number, 
                   caretX: number, caretY: number, caretRelativeX: number, caretRelativeY: number, 
                   caretWidth: number, caretHeight: number, textInputBottomTextInset: number ) => {
-                    const { height: windowHeight } = Dimensions.get( 'window' );
-                    const viewableBottomCoordinateY = keyboardEndCoordinatesScreenY ? keyboardEndCoordinatesScreenY : windowHeight - this.props.extraScrollHeight;
+                  const viewableBottomCoordinateY = this._viewableBottomCoordinateY( keyboardEndCoordinatesScreenY );
                   if ( error ) {
                     //Try old way
                     this._scrollToBottomOfComponent(currentlyFocusedField, viewableBottomCoordinateY, keyboardSpace);
@@ -515,6 +514,13 @@ function KeyboardAwareHOC(
           }
         }
       )
+    }
+
+    _viewableBottomCoordinateY( keyboardEndCoordinatesScreenY: ?number ) {
+      // When the soft keyboard is not present (using an external keyboard), `keyboardEndCoordinatesScreenY` is undefined.
+      // We will use the top most Y point from the input accessory view as the keyboard screen Y value.
+      const { height: windowHeight } = Dimensions.get( 'window' );
+      return keyboardEndCoordinatesScreenY ? keyboardEndCoordinatesScreenY : windowHeight - this.props.inputAccessoryViewHeight;
     }
 
     _totalVerticalDistanceToWindow() {
@@ -589,7 +595,7 @@ function KeyboardAwareHOC(
     }
 
     _isCaretOutOfViewableArea(caretY: number, caretHeight: number, keyboardEndCoordinatesScreenY: number) {
-      return this._isCaretUnderKeyboard(caretY, caretHeight, keyboardEndCoordinatesScreenY - this.props.extraScrollHeight ) || 
+      return this._isCaretUnderKeyboard(caretY, caretHeight, keyboardEndCoordinatesScreenY ) || 
             this._isCaretAboveViewableArea(caretY);
     }
     
@@ -612,7 +618,7 @@ function KeyboardAwareHOC(
 
     _extraScrollHeight() {
       const verticalDistanceToWindow = (this.state.keyboardEndCoordinatesScreenY !== undefined) ? this.topDistanceToWindow : this._totalVerticalDistanceToWindow();
-      return this.props.extraScrollHeight + verticalDistanceToWindow;
+      return this.props.extraScrollHeight + verticalDistanceToWindow + this.props.inputAccessoryViewHeight;
     }
 
     _doScrollToBottomOfComponent(currentlyFocusedField: number, y: number, height: number, keyboardEndCoordinatesScreenY: number, keyboardSpace: number, keyboardOpeningTime?: number) {


### PR DESCRIPTION
This PR tweaks the logic around autoscrolling when the caret goes under the keyboard.

Gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1939