### PR TITLE
Improve scroll calculations with caret under keyboard at mid paragraph

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -544,15 +544,18 @@ function KeyboardAwareHOC(
         width: number,
         height: number) => {
 
-        let keyboardScreenY = keyboardEndCoordinatesScreenY;
-        let extraScrollHeigth = caretHeight*2; //show extra space below the caret
-        let scrollOffsetY = y - keyboardScreenY + caretHeight + extraScrollHeigth + caretRelativeY + this._totalVerticalDistanceToWindow();
+        const extraScrollHeigth = caretHeight; //Show one extra line below the caret.
+        const keyboardYOnWindow = keyboardEndCoordinatesScreenY;
+        const textViewYOnScrollview = y;
+        const totalAccessoriesHeight = this.props.inputAccessoryViewHeight + this.topDistanceToWindow;
+        const caretBottomYOnScrollview = textViewYOnScrollview + caretRelativeY + caretHeight;
+        let scrollOffsetY = caretBottomYOnScrollview + totalAccessoriesHeight + extraScrollHeigth - keyboardYOnWindow;
+
         scrollOffsetY = Math.max(0, scrollOffsetY); //prevent negative scroll offset
         const responder = this.getScrollResponder();
-        responder && 
-          responder.scrollResponderScrollTo( { x: 0, y: scrollOffsetY, animated: true } );
+        responder && responder.scrollResponderScrollTo( { x: 0, y: scrollOffsetY, animated: true } );
       }
-      
+
       const measureLayoutErrorHandler = ( e: Object ) => {
         console.error('Error measuring text field: ', e);
       }


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1939

This PR improves the scroll calculations when the caret is under the keyboard and not at the last line. Now the extra space between the keyboard and the caret is even for any kind of device.

![normal](https://user-images.githubusercontent.com/9772967/76562685-308b3680-64a6-11ea-8eb7-ab0cd77c6144.gif)

![x](https://user-images.githubusercontent.com/9772967/76562691-33862700-64a6-11ea-8c05-c7bbbf4c4683.gif)

To test:
- Refer to https://github.com/wordpress-mobile/gutenberg-mobile/pull/1939